### PR TITLE
Feature/34612

### DIFF
--- a/components/01-globals/typography/link/_link.scss
+++ b/components/01-globals/typography/link/_link.scss
@@ -17,13 +17,26 @@ $link-transition       : $transition-base !default;
         color: $link-hover-color;
         text-decoration: $link-hover-decoration;
     }
-
-    &--hidden {
+    // visible only for screen readers and when focused
+    &--visually-hidden {
         position: absolute;
-        text-indent: 200%;
-        height: 0.008em;
-        width: 0.008em;
+        clip: rect(0 0 0 0);
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
         overflow: hidden;
+        border: 0;
+
+        &:focus,
+        &:active {
+            clip: auto;
+            height: auto;
+            margin: 0;
+            overflow: visible;
+            position: static;
+            width: auto;
+        }
     }
 }
 


### PR DESCRIPTION
Update visually hidden links
https://github.com/SnowdogApps/magento2-alpaca-components/issues/58
update styles, links visible only for screen readers and when are focused.

Normally we shouldn't hide links but there are some cases that it's good to put some information visibly only for people using a11y features, like 'skip to content' link or some info for forms fields.

Adjustments in alpaca-theme: https://github.com/SnowdogApps/magento2-alpaca-theme/pull/22