### PR TITLE
Add placholder to media (image/video) container - Feature/36006

### DIFF
--- a/components/01-globals/responsive-container/_responsive-container.scss
+++ b/components/01-globals/responsive-container/_responsive-container.scss
@@ -1,0 +1,81 @@
+@keyframes fadeEffect {
+  @for $i from 1 through 5 {
+    $number: $i * 20;
+    $percent: $number + "%";
+    #{$percent} {
+      opacity: $i * 2 / 10;
+    }
+  }
+}
+
+[data-aspect-ratio] {
+    display: block;
+    max-width: 100%;
+    position: relative;
+
+    &:before {
+        content: '';
+        display: block;
+    }
+
+    > * {
+        display: block;
+        height: 100%;
+        left: 0;
+        position: absolute;
+        top: 0;
+        width: 100%;
+    }
+    &:after {
+        content: 'Loading...';
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background: transparent;
+        width:100%;
+        height:100%;
+        position: absolute;
+        z-index: -1;
+        opacity: 0.5;
+        animation: fadeEffect 2s linear infinite;
+    }
+}
+[data-aspect-radio="40:39"]:before {
+    padding-top: (40 / 39) * 100%;
+}
+[data-aspect-ratio="3:1"]:before {
+    padding-top: 33.33%;
+}
+[data-aspect-ratio="2:1"]:before {
+    padding-top: 50%;
+}
+[data-aspect-ratio="16:9"]:before {
+    padding-top: 56.25%;
+}
+[data-aspect-ratio="3:2"]:before {
+    padding-top: 66.66%;
+}
+[data-aspect-ratio="4:3"]:before {
+    padding-top: 75%;
+}
+[data-aspect-ratio="1:1"]:before {
+    padding-top: 100%;
+}
+[data-aspect-ratio="1:4"]:before {
+    padding-top: 400%;
+}
+[data-aspect-ratio="3:4"]:before {
+    padding-top: 133.33%;
+}
+[data-aspect-ratio="2:3"]:before {
+    padding-top: 150%;
+}
+[data-aspect-ratio="9:16"]:before {
+    padding-top: 177.77%;
+}
+[data-aspect-ratio="1:2"]:before {
+    padding-top: 200%;
+}
+[data-aspect-ratio="1:3"]:before {
+    padding-top: 300%;
+}

--- a/components/03-modules/product/product.hbs
+++ b/components/03-modules/product/product.hbs
@@ -1,6 +1,6 @@
 <{{{ tag }}} class="product {{ class }}">
     <a href="#" class="product__link">
-        <div class="product__img-box">
+        <div data-aspect-ratio="40:39" class="product__img-box">
             {{ render '@image' image }}
         </div>
 

--- a/components/04-views/catalog/catalog.config.js
+++ b/components/04-views/catalog/catalog.config.js
@@ -7,7 +7,17 @@ module.exports = {
       price: '210$',
       type: 'some attribute text',
       image: {
-        src: '/images/product/product-img-230_180.png'
+        dataSrc: '/images/product/product-img-230_180.png'
+      }
+    },
+    product2: {
+      tag: 'li',
+      class: 'products-grid__item',
+      name: 'Some product name',
+      price: '210$',
+      type: 'some attribute text',
+      image: {
+        dataSrc: 'https://loremflickr.com/640/620/brazil,rio'
       }
     }
   },

--- a/components/04-views/catalog/catalog.hbs
+++ b/components/04-views/catalog/catalog.hbs
@@ -1,6 +1,6 @@
 <ul class="products-grid">
     {{ render '@product--with-add-to-cart-button' product }}
-    {{ render '@product--with-add-to-cart-button' product }}
+    {{ render '@product--with-add-to-cart-button' product2 }}
     {{ render '@product--with-add-to-cart-button' product }}
     {{ render '@product--with-add-to-cart-button' product }}
     {{ render '@product--with-add-to-cart-button' product }}

--- a/docs/styles/_alpaca-components.scss
+++ b/docs/styles/_alpaca-components.scss
@@ -34,6 +34,9 @@
 // Grid
 @import '../../components/01-globals/grid/grid';
 
+// Responsive container with placeholder
+@import '../../components/01-globals/responsive-container/responsive-container';
+
 // -----
 // Elements
 // -----


### PR DESCRIPTION
Refs: #110 

I was thinking if we can use such approach for #110
please check. In catalog you have example (second product should load longer to see placeholder if not use network settings).

We can also add `:after` placeholer to img and hide it if img has class lazyloaded

