### PR TITLE
Improvments to modal (a11y, cross browsers fixes), refs: 251, dev-36912

### DIFF
--- a/components/03-modules/modal/_modal.scss
+++ b/components/03-modules/modal/_modal.scss
@@ -29,6 +29,8 @@ $modal__close-button-icon-color      : $color-primary !default;
     &--active {
         display: flex;
         justify-content: center;
+        flex-direction: column;
+        align-items: center
     }
 
     &__content {

--- a/components/03-modules/modal/modal.config.js
+++ b/components/03-modules/modal/modal.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   context: {
-    class: '',
-    id: 'modal-1',
+    dialogClass: '',
+    modalClass: '',
+    modalId: 'modal-1',
     trigger: true,
     content: 'button',
     buttonClose: {
@@ -11,6 +12,7 @@ module.exports = {
       iconId: 'close',
       iconClass: 'button__icon modal__close-button-icon',
       attributes: 'type="button" aria-label="close modal button, click to close the modal"'
-    }
+    },
+    script: true
   }
 };

--- a/components/03-modules/modal/modal.hbs
+++ b/components/03-modules/modal/modal.hbs
@@ -1,12 +1,14 @@
 {{#if trigger }}
     {{ render '@modal-trigger' }}
 {{/if}}
-<div class="modal" data-modal="{{ id }}">
-    <dialog class="modal__content {{ class }}">
+<div class="modal {{ modalClass }}" data-modal="{{ modalId }}">
+    <dialog class="modal__content {{ dialogClass }}" {{{ dialogAttribtues }}}>
         {{ render (component content) contentContext }}
         {{#if buttonClose }}
             {{ render '@button--icon' buttonClose }}
         {{/if}}
     </dialog>
 </div>
+{{#if script }}
 <script src="{{static 'modal.js' }}"></script>
+{{/if}}

--- a/components/03-modules/modal/modal.js
+++ b/components/03-modules/modal/modal.js
@@ -4,13 +4,41 @@ class Modal {
     this.init();
   }
 
+  trap(e, modal) {
+    if (e.which == 27) {
+      this.closeModal(modal);
+    }
+    if (e.which == 9) {
+      let currentFocus = document.activeElement;
+      let totalOfFocusable = modal.focusableChildren.length;
+      let focusedIndex = modal.focusableChildren.indexOf(currentFocus);
+      if (e.shiftKey) {
+        if (focusedIndex === 0) {
+          e.preventDefault();
+          modal.focusableChildren[totalOfFocusable - 1].focus();
+        }
+      }
+      else {
+        if (focusedIndex == totalOfFocusable - 1) {
+          e.preventDefault();
+          modal.focusableChildren[0].focus();
+        }
+      }
+    }
+  }
 
   openModal(modal) {
     modal.el.classList.add('modal--active');
+    modal.focusableChildren = Array.from(modal.el.querySelectorAll(modal.focusable));
+    modal.focusableChildren[0].focus();
+    modal.el.addEventListener('keydown', (e) => {
+      this.trap(e, modal);
+    });
   }
 
   closeModal(modal) {
     modal.el.classList.remove('modal--active');
+    modal.focused.focus();
   }
 
   setListeners() {
@@ -50,7 +78,7 @@ class Modal {
         if (e.which === 27
           && modal.el.classList.contains('modal--active')
         ) {
-          this.closeModal(modal.el)
+          this.closeModal(modal)
         }
       });
     })

--- a/components/03-modules/modal/modal.js
+++ b/components/03-modules/modal/modal.js
@@ -28,6 +28,7 @@ class Modal {
   }
 
   openModal(modal) {
+    modal.focused = document.activeElement;
     modal.el.classList.add('modal--active');
     modal.focusableChildren = Array.from(modal.el.querySelectorAll(modal.focusable));
     modal.focusableChildren[0].focus();

--- a/components/03-modules/modal/modal.js
+++ b/components/03-modules/modal/modal.js
@@ -4,45 +4,53 @@ class Modal {
     this.init();
   }
 
-  toggleModal(modalElement) {
-    modalElement.classList.toggle('modal--active')
+
+  openModal(modal) {
+    modal.el.classList.add('modal--active');
+  }
+
+  closeModal(modal) {
+    modal.el.classList.remove('modal--active');
   }
 
   setListeners() {
     this.triggers.forEach(trigger => {
-      const triggerId           = trigger.dataset.modaltrigger,
-            modalElement        = document.querySelector(`.modal[data-modal=${triggerId}]`),
-            modalContentElement = modalElement.querySelector('.modal__content'),
-            closeButton         = modalElement.querySelector('.modal__close-button');
+      const modal = {};
+            modal.triggerId   = trigger.dataset.modaltrigger,
+            modal.el          = document.querySelector(`.modal[data-modal=${modal.triggerId}]`),
+            modal.content     = modal.el.querySelector('.modal__content'),
+            modal.closeButton = modal.el.querySelector('.modal__close-button'),
+            modal.focusable   = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), object, embed, *[tabindex], *[contenteditable]',
+            modal.focused     = '';
 
       /// When the user clicks on trigger, open the modal
       trigger.addEventListener('click',
-        () => this.toggleModal(modalElement)
+        () => this.openModal(modal)
       );
 
       // When the user clicks on button (x), close the modal
-      if (closeButton) {
-        closeButton.addEventListener('click',
-          () => this.toggleModal(modalElement)
+      if (modal.closeButton) {
+        modal.closeButton.addEventListener('click',
+          () => this.closeModal(modal)
         );
       }
 
       // When the user clicks anywhere outside of the modal, close the modal
       window.addEventListener('click', (e) => {
-        if (e.target === modalElement
-          && modalElement.classList.contains('modal--active')
-          && !modalContentElement.contains(e.target)
+        if (e.target === modal.el
+          && modal.el.classList.contains('modal--active')
+          && !modal.content.contains(e.target)
         ) {
-          this.toggleModal(modalElement)
+          this.closeModal(modal)
         }
       });
 
       // When the user push escape, close the modal
       window.addEventListener('keydown', (e) => {
         if (e.which === 27
-          && modalElement.classList.contains('modal--active')
+          && modal.el.classList.contains('modal--active')
         ) {
-          this.toggleModal(modalElement)
+          this.closeModal(modal.el)
         }
       });
     })


### PR DESCRIPTION
Refs: #251 
internal: dev-36912

A little improvements (like keeping focus inside modal) and cross-browsers fixes in displaying modal. 

Imho if we want to use dialog element we should use 
https://github.com/GoogleChrome/dialog-polyfill/blob/master/dialog-polyfill.js

as for browser who doesn't support it we should add things like `role="dialog"` etc. or better use div tag with role, etc. and make it like most of people (bootstrap, etc. etc).
