### PR TITLE
Removal of popup trigger component

### DIFF
--- a/components/02-elements/popup-trigger/popup-trigger.config.js
+++ b/components/02-elements/popup-trigger/popup-trigger.config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  context: {
-    buttonPopupTrigger: {
-      class: 'popup-trigger',
-      text: 'Popup trigger button',
-      attributes: 'data-popuptrigger="popup-1" type="button"'
-    }
-  }
-};

--- a/components/02-elements/popup-trigger/popup-trigger.hbs
+++ b/components/02-elements/popup-trigger/popup-trigger.hbs
@@ -1,1 +1,0 @@
-{{ render '@button' buttonPopupTrigger merge=true }}

--- a/components/03-modules/popup/popup.config.js
+++ b/components/03-modules/popup/popup.config.js
@@ -1,9 +1,14 @@
 module.exports = {
   context: {
-    class: '',
-    popupId: 'popup-minicart',
-    content: 'button',
     popupTrigger: true,
+    buttonPopupTrigger: {
+      class: 'popup-trigger',
+      text: 'Popup trigger button',
+      attributes: 'data-popuptrigger="popup-1" type="button"'
+    },
+    class: '',
+    popupId: 'popup-1',
+    content: 'button',
     buttonClose: {
       tag: 'button',
       text: '',

--- a/components/03-modules/popup/popup.hbs
+++ b/components/03-modules/popup/popup.hbs
@@ -1,5 +1,5 @@
 {{#if popupTrigger }}
-    {{ render '@popup-trigger' }}
+    {{ render '@button' buttonPopupTrigger merge=true }}
 {{/if}}
 <dialog data-popup="{{ popupId }}" class="popup {{ class }}" role="alertdialog" >
     <div class="popup__handler">


### PR DESCRIPTION
Origin of the problem was a broken popup component, caused by the wrong popupo id defined inside`data-popuptrigger` of the trigger button.

Passing down the configuration of the button is not that easy, so instead of doing it, I just removed this ultra simple component and moved it to the popup component itself, because that was the only place where it was in use.