### PR TITLE
Hide side-menu content from keyboard navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Rating focus style
+- Hide side-menu content from keyboard navigation
+- Fixed typo for variable in Sass catalog grid
 
 ## [1.3.1] - 30.04.2019
 ### Added

--- a/components/03-modules/side-menu/_side-menu.scss
+++ b/components/03-modules/side-menu/_side-menu.scss
@@ -45,6 +45,7 @@ $side-menu__overlay-background-color    : rgba(0, 0, 0, 0.6) !default;
         .side-menu__content {
             opacity: 1;
             transform: $side-menu__content-transform--open;
+            visibility: visible;
         }
 
         .side-menu__overlay {
@@ -115,6 +116,7 @@ $side-menu__overlay-background-color    : rgba(0, 0, 0, 0.6) !default;
         opacity: 1;
         transform: $side-menu__content-transform;
         transition: $side-menu__content-transition;
+        visibility: hidden;
         @include mq($screen-m) {
             max-width: $side-menu__content-max-width\@medium;
         }

--- a/components/04-views/catalog/grid/_grid.scss
+++ b/components/04-views/catalog/grid/_grid.scss
@@ -1,5 +1,5 @@
 $catalog-grid__gap    : $spacer--medium !default;
-$catalog-gird__margin : 0 !default;
+$catalog-grid__margin : 0 !default;
 $catalog-grid__padding: $spacer--medium 0 $spacer--large 0 !default;
 $catalog-grid__border : 1px solid $gray-light !default;
 
@@ -7,7 +7,7 @@ $catalog-grid__border : 1px solid $gray-light !default;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-gap: $catalog-grid__gap;
-    margin: $catalog-gird__margin;
+    margin: $catalog-grid__margin;
     padding: $catalog-grid__padding;
     border-bottom: $catalog-grid__border;
     list-style: none;


### PR DESCRIPTION
When `.side-menu__content` is closed it's still accessible through keyboard navigation. 
So when tabbing through the header I would expect keyboard focus to move from the side-menu icon to the logo, instead it moves to the links in the `.side-menu__content` element which is positioned outside of the viewport, but not properly hidden. Confusing the user in the process and is an accessibility concern.