### PR TITLE
fix rendering attributes for image and select elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Rendering attributes in select and image elements
+
 ### Changed
 - Password strength and datepicker styles
 

--- a/components/02-elements/form/select/select.hbs
+++ b/components/02-elements/form/select/select.hbs
@@ -13,7 +13,7 @@
         {{{ field.attributes }}}
     >
         {{#each options}}
-            <option value="{{ value }}" {{ attributes }}>
+            <option value="{{ value }}" {{{ attributes }}}>
                 {{text}}
             </option>
         {{/each}}

--- a/components/02-elements/image/image.hbs
+++ b/components/02-elements/image/image.hbs
@@ -4,6 +4,6 @@
         src="{{ src }}"
         data-src="{{ dataSrc }}"
         alt="{{ alt }}"
-        {{ attributes }}
+        {{{ attributes }}}
     >
 </div>


### PR DESCRIPTION
It would be good to merge it asap ;)

Generally it allows to pass attributes to image/select elements. Now it's not possible in components as it won't be rendered properly.

For image it is useful for example to set width/height so we can set proper aspect ratio while waiting for lazysizes to load images and avoid content jump. 

